### PR TITLE
Fix css rule and remove using jQuery

### DIFF
--- a/MMM-MD.js
+++ b/MMM-MD.js
@@ -145,7 +145,7 @@ Module.register("MMM-MD", {
 		window.setInterval(function () {
 
 			// Valore massimo che può assumere "bigWrapper.scrollTop"
-			maxima = bigWrapper.scrollHeight - $(bigWrapper).outerHeight() + staller;
+			maxima = bigWrapper.scrollHeight - bigWrapper.getBoundingClientRect().height + staller;
 
 			// E' ancora possibile scorrere verso il basso
 			if (i < maxima) {

--- a/MMM-MD.js
+++ b/MMM-MD.js
@@ -43,7 +43,7 @@ Module.register("MMM-MD", {
 		staller: 100,
 
 		// Width (larghezza) del box del modulo
-		width: "calc(100 % - 25 %)",
+		width: "calc(100% - 25%)",
 
 		// Height (altezza) del box del modulo
 		height: "500px",


### PR DESCRIPTION
This PR does two things:
1. fixes the invalid css rule - there should be no spaces between number and unit
2. removes the need of jQuery by using the native javascript methods